### PR TITLE
Fixes in generateRandomHeaders method

### DIFF
--- a/goldeneye.py
+++ b/goldeneye.py
@@ -462,7 +462,7 @@ class Striker(Process):
         # Random accept encoding
         acceptEncoding = ['\'\'','*','identity','gzip','deflate']
         random.shuffle(acceptEncoding)
-        nrEncodings = random.randint(1,len(acceptEncoding)/2)
+        nrEncodings = random.randint(1,int(len(acceptEncoding)/2))
         roundEncodings = acceptEncoding[:nrEncodings]
 
         http_headers = {


### PR DESCRIPTION
Hi, When I attempted to use the script my strikes were failing, I could trace the problem and fix it for me. 
Since there is some issues open with the same errors that I had, I decided to open this PR.

The output that I got after testing with --debug flag:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "./goldeneye.py", line 324, in run
    (url, headers) = self.createPayload()
  File "./goldeneye.py", line 357, in createPayload
    req_url, headers = self.generateData()
  File "./goldeneye.py", line 395, in generateData
    http_headers = self.generateRandomHeaders()
  File "./goldeneye.py", line 465, in generateRandomHeaders
    nrEncodings = random.randint(1,len(acceptEncoding)/2)
  File "/usr/lib/python3.6/random.py", line 221, in randint
    return self.randrange(a, b+1)
  File "/usr/lib/python3.6/random.py", line 194, in randrange
    raise ValueError("non-integer stop for randrange()")
ValueError: non-integer stop for randrange()

```